### PR TITLE
chore: upgrade InfluxDB to 2.0.0-rc

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ version: '3.8'
 
 services:
   influxdb:
-    image: quay.io/influxdb/influxdb:2.0.0-beta
+    image: quay.io/influxdb/influxdb:2.0.0-rc
     ports:
-      - "9999:9999"
+      - "8086:8086"
     volumes:
       - influx_data:/var/lib/influxdb
 


### PR DESCRIPTION
This upgrade contains breaking changes with previous versions.

Closes #54 