### PR TITLE
refactor: process gateway events using in a more reactive style

### DIFF
--- a/src/main/kotlin/com/github/shirleh/statistics/BanDataCollector.kt
+++ b/src/main/kotlin/com/github/shirleh/statistics/BanDataCollector.kt
@@ -31,13 +31,14 @@ object BanDataCollector : KoinComponent {
     /**
      * Collects ban data from the incoming [events].
      */
-    suspend fun collect(events: Flow<BanEvent>) =
-        events
-            .onEach { delay(AUDIT_LOG_UPDATE_DELAY) }
-            .mapNotNull(BanDataCollector::findBanAuthorId)
-            .map(BanDataCollector::toDataPoint)
-            .map(BanData::toDataPoint)
-            .collect(dataPointRepository::save)
+    fun addListener(events: Flow<BanEvent>) = events
+        .onEach { delay(AUDIT_LOG_UPDATE_DELAY) }
+        .mapNotNull(BanDataCollector::findBanAuthorId)
+        .map(BanDataCollector::toDataPoint)
+        .map(BanData::toDataPoint)
+        .onEach(dataPointRepository::save)
+        .catch { error -> logger.catching(error) }
+
 
     private suspend fun findBanAuthorId(event: BanEvent): Snowflake? {
         logger.entry(event)

--- a/src/main/kotlin/com/github/shirleh/statistics/NicknameDataCollector.kt
+++ b/src/main/kotlin/com/github/shirleh/statistics/NicknameDataCollector.kt
@@ -33,12 +33,13 @@ object NicknameDataCollector : KoinComponent {
     /**
      * Collects member nickname data from the incoming [events].
      */
-    suspend fun collect(events: Flow<MemberUpdateEvent>) =
-        events
-            .onEach { delay(AUDIT_LOG_UPDATE_DELAY) }
-            .mapNotNull(::findNicknameChange)
-            .map(NicknameChange::toDataPoint)
-            .collect(dataPointRepository::save)
+    fun addListener(events: Flow<MemberUpdateEvent>) = events
+        .onEach { delay(AUDIT_LOG_UPDATE_DELAY) }
+        .mapNotNull(::findNicknameChange)
+        .map(NicknameChange::toDataPoint)
+        .onEach(dataPointRepository::save)
+        .catch { error -> logger.catching(error) }
+
 
     private suspend fun findNicknameChange(event: MemberUpdateEvent): NicknameChange? {
         logger.entry(event)


### PR DESCRIPTION
This gives
- a more streamlined error handling
- a better overview of where collections of flows happens (e.g. all in `mono { ... }` in Main.kt).