### PR TITLE
bug: increase time precision of data points from seconds to milliseco…

### DIFF
--- a/src/main/kotlin/com/github/shirleh/statistics/BanDataCollector.kt
+++ b/src/main/kotlin/com/github/shirleh/statistics/BanDataCollector.kt
@@ -19,7 +19,7 @@ private data class BanData(val author: String, val count: Long = 1L) {
     fun toDataPoint() = Point.measurement("ban")
         .addTag("author", author)
         .addField("count", 1)
-        .time(Instant.now(), WritePrecision.S)
+        .time(Instant.now(), WritePrecision.MS)
 }
 
 object BanDataCollector : KoinComponent {

--- a/src/main/kotlin/com/github/shirleh/statistics/MemberJoinDataCollector.kt
+++ b/src/main/kotlin/com/github/shirleh/statistics/MemberJoinDataCollector.kt
@@ -20,7 +20,7 @@ private data class JoinData(
         .addTag("guildId", guildId)
         .addField("creationDate", creationDate.epochSecond)
         .addField("isBoosting", isBoosting)
-        .time(joinTime, WritePrecision.S)
+        .time(joinTime, WritePrecision.MS)
 }
 
 object MemberJoinDataCollector : KoinComponent {

--- a/src/main/kotlin/com/github/shirleh/statistics/MemberLeaveDataCollector.kt
+++ b/src/main/kotlin/com/github/shirleh/statistics/MemberLeaveDataCollector.kt
@@ -22,7 +22,7 @@ private data class LeaveData(
         .addTag("guildId", guildId)
         .addField("membershipDuration", membershipDuration.seconds)
         .addField("isBoosting", isBoosting)
-        .time(leaveTime, WritePrecision.S)
+        .time(leaveTime, WritePrecision.MS)
 }
 
 object MemberLeaveDataCollector : KoinComponent {

--- a/src/main/kotlin/com/github/shirleh/statistics/NicknameDataCollector.kt
+++ b/src/main/kotlin/com/github/shirleh/statistics/NicknameDataCollector.kt
@@ -21,7 +21,7 @@ private data class NicknameChange(val author: String, val oldNickname: String, v
         .addTag("author", author)
         .addField("oldNickname", oldNickname)
         .addField("currentNickname", newNickname)
-        .time(Instant.now(), WritePrecision.S)
+        .time(Instant.now(), WritePrecision.MS)
 }
 
 object NicknameDataCollector : KoinComponent {

--- a/src/main/kotlin/com/github/shirleh/statistics/VoiceDataCollector.kt
+++ b/src/main/kotlin/com/github/shirleh/statistics/VoiceDataCollector.kt
@@ -30,7 +30,7 @@ private data class VoiceStateData(
         .addField("isSelfMuted", isSelfMuted)
         .addField("isDeafened", isDeafened)
         .addField("isSelfDeafened", isSelfDeafened)
-        .time(Instant.now(), WritePrecision.S)
+        .time(Instant.now(), WritePrecision.MS)
 }
 
 object VoiceDataCollector : KoinComponent {

--- a/src/main/kotlin/com/github/shirleh/statistics/emoji/Emoji.kt
+++ b/src/main/kotlin/com/github/shirleh/statistics/emoji/Emoji.kt
@@ -22,5 +22,5 @@ internal data class Emoji(
             .addTag("source", source.name)
             .addTag("type", type.name)
             .addField("id", value)
-            .time(Instant.now(), WritePrecision.S)
+            .time(Instant.now(), WritePrecision.MS)
 }

--- a/src/main/kotlin/com/github/shirleh/statistics/message/MessageDataCollector.kt
+++ b/src/main/kotlin/com/github/shirleh/statistics/message/MessageDataCollector.kt
@@ -25,7 +25,7 @@ private data class MessageData(
         .addTag("channel", channelId)
         .addTag("author", authorId)
         .addField("count", count)
-        .time(timestamp, WritePrecision.S)
+        .time(timestamp, WritePrecision.MS)
 }
 
 object MessageDataCollector : KoinComponent {


### PR DESCRIPTION
…nds to prevent collisions

InfluxDB considers data points with the same *measurement*, *tag set* and *timestamp* to be equal. Two messages sent in the same second will therefore be considered a duplicate. To prevent this, the time precision is set to milliseconds.